### PR TITLE
CP-346: Create 'recommended' preset for ESlint (w/ ~ current FE monorepo standards) in the open-turo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,33 @@ Install the package and all of its peer dependencies:
 npx install-peerdeps --dev @open-turo/eslint-config-typescript
 ```
 
-Then in your `.eslintrc` file add:
+Then in your `.eslintrc` file extend from one of the two configurations included in this package:
+
+1. The default, recommended for new Typescript projects
+2. The "legacy", which is used by `eslint-config-react`, to support our existing front-end projects
+
+### Default config (for new projects)
+
+The default config of this repo is the recommended version for new Typescript projects.
+
+To use this config, just add to your `.eslintrc` the following:
 
 ```
 "extends": "@open-turo/eslint-config-typescript"
 ```
+
+### Legacy config (for some internal front-end projects)
+
+We also provide an alternative `legacy` preset, which is used by `eslint-config-react`, for compatibility with our
+existing front-end projects.
+
+If you want to use this `legacy` configuration, you can import it by instead adding the following to your `.eslintrc`:
+
+```
+"extends": "@open-turo/eslint-config-typescript/legacy"
+```
+
+Simply notice the `/legacy` suffix, which points to the `legacy.js` file in this repository.
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   root: true,
   env: {
-    node: true,
     es2022: true,
   },
   parser: "@typescript-eslint/parser",

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
     "import/no-default-export": "error",
     "import/no-extraneous-dependencies": [
       "error",
-      { devDependencies: ["src/**/__tests__/**"] },
+      { devDependencies: ["test/**/"] },
     ],
     "import/prefer-default-export": "off",
     "jest/no-jest-import": "off",

--- a/legacy.js
+++ b/legacy.js
@@ -1,13 +1,12 @@
 module.exports = {
   root: true,
   env: {
-    browser: true,
     es6: true,
     jest: true,
     node: true,
   },
   parser: "@typescript-eslint/parser",
-  ignorePatterns: ["babel.config.js", "jest.config.js"],
+  ignorePatterns: ["jest.config.js"],
   plugins: [
     "@typescript-eslint",
     "import",
@@ -64,13 +63,7 @@ module.exports = {
     "node/no-unpublished-import": [
       "error",
       {
-        allowModules: [
-          "@jest/globals",
-          "@testing-library/dom",
-          "@testing-library/react",
-          "@testing-library/user-event",
-          "nock",
-        ],
+        allowModules: ["@jest/globals"],
       },
     ],
     "node/no-unsupported-features/es-syntax": "off",

--- a/legacy.js
+++ b/legacy.js
@@ -93,7 +93,7 @@ module.exports = {
     ],
     "@typescript-eslint/unbound-method": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
-    // All the following TS-related rules turned to warnings are caused by the module not being "TS native"
+    // Any-related TS rules are turned to warn to allow building "non-TS-native" packages w/ many occurrences of them
     "@typescript-eslint/no-unsafe-argument": ["warn"],
     "@typescript-eslint/no-unsafe-return": ["warn"],
     "@typescript-eslint/no-unsafe-call": ["warn"],

--- a/legacy.js
+++ b/legacy.js
@@ -3,7 +3,6 @@ module.exports = {
   env: {
     es6: true,
     jest: true,
-    node: true,
   },
   parser: "@typescript-eslint/parser",
   ignorePatterns: ["jest.config.js"],

--- a/legacy.js
+++ b/legacy.js
@@ -1,0 +1,113 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es6: true,
+    jest: true,
+    node: true,
+  },
+  parser: "@typescript-eslint/parser",
+  ignorePatterns: ["babel.config.js", "jest.config.js"],
+  plugins: [
+    "@typescript-eslint",
+    "import",
+    "jest",
+    "node",
+    "prettier",
+    "simple-import-sort",
+    "sonarjs",
+    "sort-destructure-keys",
+    "typescript-sort-keys",
+    "eslint-plugin-jest",
+  ],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+    "plugin:jest/recommended",
+    "plugin:node/recommended",
+    "plugin:prettier/recommended",
+    "plugin:sonarjs/recommended",
+    "plugin:typescript-sort-keys/recommended",
+  ],
+  parserOptions: {
+    ecmaVersion: 2022,
+    project: "./tsconfig.json",
+  },
+  overrides: [
+    {
+      files: ["test/**"],
+      plugins: ["jest"],
+      rules: {
+        // this turns the original rule off *only* for test files, for jest compatibility
+        "@typescript-eslint/unbound-method": "off",
+        "jest/unbound-method": "error",
+      },
+    },
+  ],
+  rules: {
+    "import/default": "off",
+    "import/named": "off",
+    "import/namespace": "off",
+    "import/no-default-export": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: ["test/**/*.tsx", "test/**/*.ts"],
+      },
+    ],
+    "import/export": "off",
+    "import/prefer-default-export": "off",
+    "jest/no-jest-import": "off",
+    "node/no-unpublished-import": [
+      "error",
+      {
+        allowModules: [
+          "@jest/globals",
+          "@testing-library/dom",
+          "@testing-library/react",
+          "@testing-library/user-event",
+          "nock",
+        ],
+      },
+    ],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": "off",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "sort-destructure-keys/sort-destructure-keys": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        // Allow to name unused vars with _
+        argsIgnorePattern: "^_",
+      },
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        allowBoolean: true,
+      },
+    ],
+    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    // All the following TS-related rules turned to warnings are caused by the module not being "TS native"
+    "@typescript-eslint/no-unsafe-argument": ["warn"],
+    "@typescript-eslint/no-unsafe-return": ["warn"],
+    "@typescript-eslint/no-unsafe-call": ["warn"],
+    "@typescript-eslint/no-unsafe-member-access": ["warn"],
+    "@typescript-eslint/no-unsafe-assignment": ["warn"],
+  },
+  settings: {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"],
+    },
+    "import/resolver": {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "eslint-plugin-sonarjs": "^0.16.0",
     "eslint-plugin-sort-destructure-keys": "^1.4.0",
-    "eslint-plugin-typescript-sort-keys": "^2.1.0",
+    "eslint-plugin-typescript-sort-keys": "^2.1.0"
+  },
+  "optionalDependencies": {
     "eslint-plugin-unicorn": "^45.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
**Description**

The detailed description referencing some Turo repositories is in our internal Jira system ([see particular comment](https://team-turo.atlassian.net/browse/CP-346?focusedCommentId=183612)).

This PR includes some changes to the default preset, including changes in the `test` directory structure to follow our internal conventions. This causes a breaking change.

Also, this PR creates a new `legacy.js` file, which includes configuration for our front-end projects.
Even though the default preset remains to be the existing one as the `index.js`, the new `legacy` preset can also be extended from projects that depend on this package, as noted in the README.

**Breaking change**: as noted above, this PR includes a breaking change. Repositories currently extending this `eslint` config package are expected to follow the `/test` directory structure convention, rather than the previous `src/**/__tests__/**`

Fixes [#CP-346](https://team-turo.atlassian.net/browse/CP-346)

**Changes**

* refactor: current eslint conf to 'strict'
* feat: default to new recommended settings
* docs: added guidelines to use one of the two configs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
