### PR TITLE
fix: switching eslint dep ver from >= to ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
-    "eslint": ">=8.18.0",
+    "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.3.0",
     "eslint-plugin-import": "^2.25.4",


### PR DESCRIPTION
Switching eslint dep ver from `>=` to `^`.

As it felt too loose to allow even major version changes which would probably have effects in other peerDependencies.

Looking into the commit history, it seems we have been using the `>=` approach for `eslint` version since the creation of the repository. But unless I'm missing something, `^` seems like a better (safer) approach.