### PR TITLE
Bring legacy and default presets closer by sharing relevant config between them

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ module.exports = {
   root: true,
   env: {
     es2022: true,
+    jest: true,
   },
   parser: "@typescript-eslint/parser",
   plugins: [
     "@typescript-eslint",
+    "eslint-plugin-jest",
     "import",
     "jest",
     "json",
@@ -36,6 +38,17 @@ module.exports = {
     project: "./tsconfig.json",
     sourceType: "module",
   },
+  overrides: [
+    {
+      files: ["test/**"],
+      plugins: ["jest"],
+      rules: {
+        // this turns the original rule off *only* for test files, for jest compatibility
+        "@typescript-eslint/unbound-method": "off",
+        "jest/unbound-method": "error",
+      },
+    },
+  ],
   rules: {
     "import/default": "off",
     "import/named": "off",
@@ -66,6 +79,7 @@ module.exports = {
         argsIgnorePattern: "^_",
       },
     ],
+    "@typescript-eslint/unbound-method": "error",
   },
   settings: {
     "import/parsers": {

--- a/legacy.js
+++ b/legacy.js
@@ -1,13 +1,14 @@
 module.exports = {
   root: true,
   env: {
-    es6: true,
+    es2022: true,
     jest: true,
   },
   parser: "@typescript-eslint/parser",
   ignorePatterns: ["jest.config.js"],
   plugins: [
     "@typescript-eslint",
+    "eslint-plugin-jest",
     "import",
     "jest",
     "json",
@@ -17,7 +18,6 @@ module.exports = {
     "sonarjs",
     "sort-destructure-keys",
     "typescript-sort-keys",
-    "eslint-plugin-jest",
   ],
   extends: [
     "eslint:recommended",


### PR DESCRIPTION

**Description**

This PR brings default and legacy presets closer to each other
    
On the legacy preset front, we bump it to use es2022; and also reorder its plugins alphabetically
On the defaul preset front, we add the jest env, jest plugin and apply its specific config for the `unbound-method` rule, overriding it when linting test files, adding support for understanding when it's ok to pass an unbound method to expect calls.

**Changes**

* style: bring default and legacy presets closer

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
