### PR TITLE
Add prefer-ts-expect-error, as it is a clear improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = {
         argsIgnorePattern: "^_",
       },
     ],
+    "@typescript-eslint/prefer-ts-expect-error": "error",
     "@typescript-eslint/unbound-method": "error",
   },
   settings: {

--- a/legacy.js
+++ b/legacy.js
@@ -88,6 +88,7 @@ module.exports = {
     ],
     "@typescript-eslint/unbound-method": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/prefer-ts-expect-error": "error",
     // Any-related TS rules are turned to warn to allow building "non-TS-native" packages w/ many occurrences of them
     "@typescript-eslint/no-unsafe-argument": ["warn"],
     "@typescript-eslint/no-unsafe-return": ["warn"],


### PR DESCRIPTION
**Description**

It has a clear advantage (erroring if no-longer necessary) and no disadvantages.

**Changes**

* feat: add prefer-ts-expect-error rule

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
