### PR TITLE
Add 'nock' exclusion in node/no-unpublished-import to avoid errors in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = {
     "node/no-unpublished-import": [
       "error",
       {
-        allowModules: ["@jest/globals"],
+        allowModules: ["@jest/globals", "nock"],
       },
     ],
     "node/no-unsupported-features/es-syntax": "off",


### PR DESCRIPTION

**Description**

Otherwise, the `node/no-unpublished-import` rule will cause errors in tests that use nock (usual message: `"nock" is not published`)

**Changes**

* feat: add nock to allowed modules in node/no-unpublished-import

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
