### PR TITLE
Add 'nock' exclusion in node/no-unpublished-import to avoid errors in tests (2/2)

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -65,7 +65,7 @@ module.exports = {
     "node/no-unpublished-import": [
       "error",
       {
-        allowModules: ["@jest/globals"],
+        allowModules: ["@jest/globals", "nock"],
       },
     ],
     "node/no-unsupported-features/es-syntax": "off",


### PR DESCRIPTION

**Description**

Follow-up to https://github.com/open-turo/eslint-config-typescript/pull/160.
Missed adding the change to the legacy preset.

**Changes**

* feat: add nock to allowed modules in node/no-unpublished-import

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
