### PR TITLE
ci(release): use NPM instead of the action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,13 +14,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Setup tools
+        uses: open-turo/action-setup-tools@v1
+      - name: Install dependencies
+        run: npm ci
       - name: Semantic release
         id: release
-        uses: cycjimmy/semantic-release-action@v3
-        with:
-          semantic_version: 21
-          extra_plugins: |
-            @open-turo/semantic-release-config
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "license": "MIT",
   "main": "index.js",
   "name": "@open-turo/eslint-config-typescript",
+  "scripts": {
+    "release": "semantic-release"
+  },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",


### PR DESCRIPTION

**Description**

Semantic release action does not support Node 18 or semantic-release 21

**Changes**

* ci(release): use NPM instead of the action

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
