### PR TITLE
fix: use better matcher for test files

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
     "import/no-default-export": "error",
     "import/no-extraneous-dependencies": [
       "error",
-      { devDependencies: ["test/**/"] },
+      { devDependencies: ["test/**"] },
     ],
     "import/prefer-default-export": "off",
     "jest/no-jest-import": "off",


### PR DESCRIPTION

**Description**

If tests are defined right under `test/` this rule is not applying.

**Changes**

* fix: use better matcher for test files

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
