### PR TITLE
fix: revert eslint-plugin-json upgrade from v4 to v3 for eslint v8 comp

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
     "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:jest/recommended",
-    "plugin:json/recommended-legacy",
+    "plugin:json/recommended",
     "plugin:node/recommended",
     "plugin:prettier/recommended",
     "plugin:sonarjs/recommended-legacy",

--- a/legacy.js
+++ b/legacy.js
@@ -26,7 +26,7 @@ module.exports = {
     "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:jest/recommended",
-    "plugin:json/recommended-legacy",
+    "plugin:json/recommended",
     "plugin:node/recommended",
     "plugin:prettier/recommended",
     "plugin:sonarjs/recommended-legacy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-import-resolver-typescript": "3.6.1",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jest": "28.6.0",
-        "eslint-plugin-json": "4.0.0",
+        "eslint-plugin-json": "3.1.0",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "5.2.1",
         "eslint-plugin-simple-import-sort": "12.1.1",
@@ -2810,15 +2810,15 @@
       }
     },
     "node_modules/eslint-plugin-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-4.0.0.tgz",
-      "integrity": "sha512-l/P3WTzl2HI8PbwsbDIrZ+6jvwQI4TGuz20ReJkG3Y+gZS5ZurTgx+gBmuLpOgiqMyDJWyJ7+GCjevWtNYQcUg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
       "dependencies": {
         "lodash": "^4.17.21",
         "vscode-json-languageservice": "^4.1.6"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -8490,9 +8490,9 @@
       }
     },
     "eslint-plugin-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-4.0.0.tgz",
-      "integrity": "sha512-l/P3WTzl2HI8PbwsbDIrZ+6jvwQI4TGuz20ReJkG3Y+gZS5ZurTgx+gBmuLpOgiqMyDJWyJ7+GCjevWtNYQcUg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
       "requires": {
         "lodash": "^4.17.21",
         "vscode-json-languageservice": "^4.1.6"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-import-resolver-typescript": "3.6.1",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jest": "28.6.0",
-    "eslint-plugin-json": "4.0.0",
+    "eslint-plugin-json": "3.1.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-simple-import-sort": "12.1.1",


### PR DESCRIPTION
From https://github.com/azeemba/eslint-plugin-json: `If you are using eslint v9 or newer, use eslint-plugin-json v4 or newer.` The "legacy" package was added in v4, but v4 only supports flat configs.