### PR TITLE
ci: use latest actions-node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
           mkdir -p "$HOME/bin"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/bin"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
-      - uses: open-turo/actions-node/lint@v5
+      - uses: open-turo/actions-node/lint@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.OPEN_TURO_NPM_TOKEN }}
@@ -22,7 +22,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-node/test@v5
+      - uses: open-turo/actions-node/test@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-flags: --coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: open-turo/actions-node/release@v5
+      - uses: open-turo/actions-node/release@v6
         with:
           github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
           npm-token: ${{ secrets.OPEN_TURO_NPM_TOKEN }}


### PR DESCRIPTION

**Description**

Not sure why renovatebot is not picking these


**Changes**

* ci: use latest actions-node

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
