### PR TITLE
test: add snapshot with compiled rule list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "echo noop",
     "lint": "echo noop",
-    "test": "jest test.js"
+    "test": "jest ./test/test.spec.js"
   },
   "peerDependencies": {
     "eslint": "^8.18.0",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -1,0 +1,2552 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validate config load config file in ESLint to validate all rules are correct 1`] = `
+{
+  "env": {
+    "es2022": true,
+    "es2024": true,
+    "jest": true,
+    "jest/globals": true,
+  },
+  "globals": {
+    "ArrayBuffer": "readonly",
+    "Atomics": "readonly",
+    "BigInt": "readonly",
+    "BigInt64Array": "readonly",
+    "BigUint64Array": "readonly",
+    "Buffer": "readonly",
+    "DataView": "readonly",
+    "Float32Array": "readonly",
+    "Float64Array": "readonly",
+    "GLOBAL": "readonly",
+    "Int16Array": "readonly",
+    "Int32Array": "readonly",
+    "Int8Array": "readonly",
+    "Intl": "readonly",
+    "Map": "readonly",
+    "Promise": "readonly",
+    "Proxy": "readonly",
+    "Reflect": "readonly",
+    "Set": "readonly",
+    "SharedArrayBuffer": "readonly",
+    "Symbol": "readonly",
+    "TextDecoder": "readonly",
+    "TextEncoder": "readonly",
+    "URL": "readonly",
+    "URLSearchParams": "readonly",
+    "Uint16Array": "readonly",
+    "Uint32Array": "readonly",
+    "Uint8Array": "readonly",
+    "Uint8ClampedArray": "readonly",
+    "WeakMap": "readonly",
+    "WeakSet": "readonly",
+    "WebAssembly": "readonly",
+    "__dirname": "readonly",
+    "__filename": "readonly",
+    "clearImmediate": "readonly",
+    "clearInterval": "readonly",
+    "clearTimeout": "readonly",
+    "console": "readonly",
+    "exports": "writable",
+    "global": "readonly",
+    "globalThis": "readonly",
+    "module": "readonly",
+    "process": "readonly",
+    "queueMicrotask": "readonly",
+    "require": "readonly",
+    "root": "readonly",
+    "setImmediate": "readonly",
+    "setInterval": "readonly",
+    "setTimeout": "readonly",
+  },
+  "ignorePatterns": [],
+  "noInlineConfig": undefined,
+  "parserOptions": {
+    "ecmaFeatures": {
+      "globalReturn": true,
+    },
+    "ecmaVersion": "latest",
+    "project": "./tsconfig.json",
+    "sourceType": "module",
+  },
+  "plugins": [
+    "unicorn",
+    "typescript-sort-keys",
+    "sort-destructure-keys",
+    "sonarjs",
+    "simple-import-sort",
+    "prettier",
+    "node",
+    "json",
+    "import",
+    "@typescript-eslint",
+    "jest",
+  ],
+  "reportUnusedDisableDirectives": undefined,
+  "rules": {
+    "@babel/object-curly-spacing": [
+      "off",
+    ],
+    "@babel/semi": [
+      "off",
+    ],
+    "@typescript-eslint/await-thenable": [
+      "error",
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+    ],
+    "@typescript-eslint/block-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/brace-style": [
+      "off",
+    ],
+    "@typescript-eslint/comma-dangle": [
+      "off",
+    ],
+    "@typescript-eslint/comma-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "disallowTypeAnnotations": true,
+        "fixStyle": "inline-type-imports",
+        "prefer": "type-imports",
+      },
+    ],
+    "@typescript-eslint/func-call-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/indent": [
+      "off",
+    ],
+    "@typescript-eslint/key-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/keyword-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/lines-around-comment": [
+      0,
+    ],
+    "@typescript-eslint/member-delimiter-style": [
+      "off",
+    ],
+    "@typescript-eslint/no-array-constructor": [
+      "error",
+    ],
+    "@typescript-eslint/no-array-delete": [
+      "error",
+    ],
+    "@typescript-eslint/no-base-to-string": [
+      "error",
+    ],
+    "@typescript-eslint/no-duplicate-enum-values": [
+      "error",
+    ],
+    "@typescript-eslint/no-duplicate-type-constituents": [
+      "error",
+    ],
+    "@typescript-eslint/no-empty-object-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-explicit-any": [
+      "error",
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [
+      "error",
+    ],
+    "@typescript-eslint/no-extra-parens": [
+      "off",
+    ],
+    "@typescript-eslint/no-extra-semi": [
+      "off",
+    ],
+    "@typescript-eslint/no-floating-promises": [
+      "error",
+    ],
+    "@typescript-eslint/no-for-in-array": [
+      "error",
+    ],
+    "@typescript-eslint/no-implied-eval": [
+      "error",
+    ],
+    "@typescript-eslint/no-import-type-side-effects": [
+      "error",
+    ],
+    "@typescript-eslint/no-misused-new": [
+      "error",
+    ],
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+    ],
+    "@typescript-eslint/no-namespace": [
+      "error",
+    ],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [
+      "error",
+    ],
+    "@typescript-eslint/no-redundant-type-constituents": [
+      "error",
+    ],
+    "@typescript-eslint/no-require-imports": [
+      "error",
+    ],
+    "@typescript-eslint/no-this-alias": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-assertion": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-constraint": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-argument": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-assignment": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-call": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-declaration-merging": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-enum-comparison": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-function-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-member-access": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-return": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-unary-minus": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+      },
+    ],
+    "@typescript-eslint/no-wrapper-object-types": [
+      "error",
+    ],
+    "@typescript-eslint/object-curly-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/only-throw-error": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-as-const": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-promise-reject-errors": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-ts-expect-error": [
+      "error",
+    ],
+    "@typescript-eslint/quotes": [
+      0,
+    ],
+    "@typescript-eslint/require-await": [
+      "error",
+    ],
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+    ],
+    "@typescript-eslint/semi": [
+      "off",
+    ],
+    "@typescript-eslint/space-before-blocks": [
+      "off",
+    ],
+    "@typescript-eslint/space-before-function-paren": [
+      "off",
+    ],
+    "@typescript-eslint/space-infix-ops": [
+      "off",
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error",
+    ],
+    "@typescript-eslint/type-annotation-spacing": [
+      "off",
+    ],
+    "@typescript-eslint/unbound-method": [
+      "off",
+    ],
+    "array-bracket-newline": [
+      "off",
+    ],
+    "array-bracket-spacing": [
+      "off",
+    ],
+    "array-element-newline": [
+      "off",
+    ],
+    "arrow-body-style": [
+      "off",
+    ],
+    "arrow-parens": [
+      "off",
+    ],
+    "arrow-spacing": [
+      "off",
+    ],
+    "babel/object-curly-spacing": [
+      "off",
+    ],
+    "babel/quotes": [
+      0,
+    ],
+    "babel/semi": [
+      "off",
+    ],
+    "block-spacing": [
+      "off",
+    ],
+    "brace-style": [
+      "off",
+    ],
+    "comma-dangle": [
+      "off",
+    ],
+    "comma-spacing": [
+      "off",
+    ],
+    "comma-style": [
+      "off",
+    ],
+    "computed-property-spacing": [
+      "off",
+    ],
+    "constructor-super": [
+      "off",
+    ],
+    "curly": [
+      0,
+    ],
+    "dot-location": [
+      "off",
+    ],
+    "eol-last": [
+      "off",
+    ],
+    "flowtype/boolean-style": [
+      "off",
+    ],
+    "flowtype/delimiter-dangle": [
+      "off",
+    ],
+    "flowtype/generic-spacing": [
+      "off",
+    ],
+    "flowtype/object-type-curly-spacing": [
+      "off",
+    ],
+    "flowtype/object-type-delimiter": [
+      "off",
+    ],
+    "flowtype/quotes": [
+      "off",
+    ],
+    "flowtype/semi": [
+      "off",
+    ],
+    "flowtype/space-after-type-colon": [
+      "off",
+    ],
+    "flowtype/space-before-generic-bracket": [
+      "off",
+    ],
+    "flowtype/space-before-type-colon": [
+      "off",
+    ],
+    "flowtype/union-intersection-spacing": [
+      "off",
+    ],
+    "for-direction": [
+      "error",
+    ],
+    "func-call-spacing": [
+      "off",
+    ],
+    "function-call-argument-newline": [
+      "off",
+    ],
+    "function-paren-newline": [
+      "off",
+    ],
+    "generator-star": [
+      "off",
+    ],
+    "generator-star-spacing": [
+      "off",
+    ],
+    "getter-return": [
+      "off",
+    ],
+    "implicit-arrow-linebreak": [
+      "off",
+    ],
+    "import/default": [
+      "off",
+    ],
+    "import/export": [
+      "error",
+    ],
+    "import/named": [
+      "off",
+    ],
+    "import/namespace": [
+      "off",
+    ],
+    "import/no-default-export": [
+      "error",
+    ],
+    "import/no-duplicates": [
+      "warn",
+    ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": [
+          "test/**",
+        ],
+      },
+    ],
+    "import/no-named-as-default": [
+      "warn",
+    ],
+    "import/no-named-as-default-member": [
+      "warn",
+    ],
+    "import/no-unresolved": [
+      "error",
+    ],
+    "import/prefer-default-export": [
+      "off",
+    ],
+    "indent": [
+      "off",
+    ],
+    "indent-legacy": [
+      "off",
+    ],
+    "jest/expect-expect": [
+      "warn",
+    ],
+    "jest/no-alias-methods": [
+      "error",
+    ],
+    "jest/no-commented-out-tests": [
+      "warn",
+    ],
+    "jest/no-conditional-expect": [
+      "error",
+    ],
+    "jest/no-deprecated-functions": [
+      "error",
+    ],
+    "jest/no-disabled-tests": [
+      "warn",
+    ],
+    "jest/no-done-callback": [
+      "error",
+    ],
+    "jest/no-export": [
+      "error",
+    ],
+    "jest/no-focused-tests": [
+      "error",
+    ],
+    "jest/no-identical-title": [
+      "error",
+    ],
+    "jest/no-interpolation-in-snapshots": [
+      "error",
+    ],
+    "jest/no-jasmine-globals": [
+      "error",
+    ],
+    "jest/no-jest-import": [
+      "off",
+    ],
+    "jest/no-mocks-import": [
+      "error",
+    ],
+    "jest/no-standalone-expect": [
+      "error",
+    ],
+    "jest/no-test-prefixes": [
+      "error",
+    ],
+    "jest/unbound-method": [
+      "error",
+    ],
+    "jest/valid-describe-callback": [
+      "error",
+    ],
+    "jest/valid-expect": [
+      "error",
+    ],
+    "jest/valid-expect-in-promise": [
+      "error",
+    ],
+    "jest/valid-title": [
+      "error",
+    ],
+    "json/*": [
+      "error",
+    ],
+    "jsx-quotes": [
+      "off",
+    ],
+    "key-spacing": [
+      "off",
+    ],
+    "keyword-spacing": [
+      "off",
+    ],
+    "linebreak-style": [
+      "off",
+    ],
+    "lines-around-comment": [
+      0,
+    ],
+    "max-len": [
+      0,
+    ],
+    "max-statements-per-line": [
+      "off",
+    ],
+    "multiline-ternary": [
+      "off",
+    ],
+    "new-parens": [
+      "off",
+    ],
+    "newline-per-chained-call": [
+      "off",
+    ],
+    "no-array-constructor": [
+      "off",
+    ],
+    "no-arrow-condition": [
+      "off",
+    ],
+    "no-async-promise-executor": [
+      "error",
+    ],
+    "no-case-declarations": [
+      "error",
+    ],
+    "no-class-assign": [
+      "off",
+    ],
+    "no-comma-dangle": [
+      "off",
+    ],
+    "no-compare-neg-zero": [
+      "error",
+    ],
+    "no-cond-assign": [
+      "error",
+    ],
+    "no-confusing-arrow": [
+      0,
+    ],
+    "no-const-assign": [
+      "off",
+    ],
+    "no-constant-condition": [
+      "error",
+    ],
+    "no-control-regex": [
+      "error",
+    ],
+    "no-debugger": [
+      "error",
+    ],
+    "no-delete-var": [
+      "error",
+    ],
+    "no-dupe-args": [
+      "off",
+    ],
+    "no-dupe-class-members": [
+      "off",
+    ],
+    "no-dupe-else-if": [
+      "error",
+    ],
+    "no-dupe-keys": [
+      "off",
+    ],
+    "no-duplicate-case": [
+      "error",
+    ],
+    "no-empty": [
+      "error",
+    ],
+    "no-empty-character-class": [
+      "error",
+    ],
+    "no-empty-pattern": [
+      "error",
+    ],
+    "no-ex-assign": [
+      "error",
+    ],
+    "no-extra-boolean-cast": [
+      "error",
+    ],
+    "no-extra-parens": [
+      "off",
+    ],
+    "no-extra-semi": [
+      "off",
+    ],
+    "no-fallthrough": [
+      "error",
+    ],
+    "no-floating-decimal": [
+      "off",
+    ],
+    "no-func-assign": [
+      "off",
+    ],
+    "no-global-assign": [
+      "error",
+    ],
+    "no-implied-eval": [
+      "off",
+    ],
+    "no-import-assign": [
+      "off",
+    ],
+    "no-inner-declarations": [
+      "error",
+    ],
+    "no-invalid-regexp": [
+      "error",
+    ],
+    "no-irregular-whitespace": [
+      "error",
+    ],
+    "no-loss-of-precision": [
+      "error",
+    ],
+    "no-misleading-character-class": [
+      "error",
+    ],
+    "no-mixed-operators": [
+      0,
+    ],
+    "no-mixed-spaces-and-tabs": [
+      "off",
+    ],
+    "no-multi-spaces": [
+      "off",
+    ],
+    "no-multiple-empty-lines": [
+      "off",
+    ],
+    "no-negated-condition": [
+      "off",
+    ],
+    "no-nested-ternary": [
+      "off",
+    ],
+    "no-new-native-nonconstructor": [
+      "off",
+    ],
+    "no-new-symbol": [
+      "off",
+    ],
+    "no-nonoctal-decimal-escape": [
+      "error",
+    ],
+    "no-obj-calls": [
+      "off",
+    ],
+    "no-octal": [
+      "error",
+    ],
+    "no-process-exit": [
+      "error",
+    ],
+    "no-prototype-builtins": [
+      "error",
+    ],
+    "no-redeclare": [
+      "off",
+    ],
+    "no-regex-spaces": [
+      "error",
+    ],
+    "no-reserved-keys": [
+      "off",
+    ],
+    "no-self-assign": [
+      "error",
+    ],
+    "no-setter-return": [
+      "off",
+    ],
+    "no-shadow-restricted-names": [
+      "error",
+    ],
+    "no-space-before-semi": [
+      "off",
+    ],
+    "no-spaced-func": [
+      "off",
+    ],
+    "no-sparse-arrays": [
+      "error",
+    ],
+    "no-tabs": [
+      0,
+    ],
+    "no-this-before-super": [
+      "off",
+    ],
+    "no-throw-literal": [
+      "off",
+    ],
+    "no-trailing-spaces": [
+      "off",
+    ],
+    "no-undef": [
+      "off",
+    ],
+    "no-unexpected-multiline": [
+      0,
+    ],
+    "no-unreachable": [
+      "off",
+    ],
+    "no-unsafe-finally": [
+      "error",
+    ],
+    "no-unsafe-negation": [
+      "off",
+    ],
+    "no-unsafe-optional-chaining": [
+      "error",
+    ],
+    "no-unused-expressions": [
+      "off",
+    ],
+    "no-unused-labels": [
+      "error",
+    ],
+    "no-unused-vars": [
+      "off",
+    ],
+    "no-useless-backreference": [
+      "error",
+    ],
+    "no-useless-catch": [
+      "error",
+    ],
+    "no-useless-escape": [
+      "error",
+    ],
+    "no-var": [
+      "error",
+    ],
+    "no-whitespace-before-property": [
+      "off",
+    ],
+    "no-with": [
+      "error",
+    ],
+    "no-wrap-func": [
+      "off",
+    ],
+    "node/no-deprecated-api": [
+      "error",
+    ],
+    "node/no-exports-assign": [
+      "error",
+    ],
+    "node/no-extraneous-import": [
+      "error",
+    ],
+    "node/no-extraneous-require": [
+      "error",
+    ],
+    "node/no-missing-import": [
+      "off",
+    ],
+    "node/no-missing-require": [
+      "error",
+    ],
+    "node/no-unpublished-bin": [
+      "error",
+    ],
+    "node/no-unpublished-import": [
+      "error",
+      {
+        "allowModules": [
+          "@jest/globals",
+          "nock",
+        ],
+      },
+    ],
+    "node/no-unpublished-require": [
+      "error",
+    ],
+    "node/no-unsupported-features/es-builtins": [
+      "error",
+    ],
+    "node/no-unsupported-features/es-syntax": [
+      "off",
+      {
+        "ignores": [],
+      },
+    ],
+    "node/no-unsupported-features/node-builtins": [
+      "error",
+    ],
+    "node/process-exit-as-throw": [
+      "error",
+    ],
+    "node/shebang": [
+      "error",
+    ],
+    "nonblock-statement-body-position": [
+      "off",
+    ],
+    "object-curly-newline": [
+      "off",
+    ],
+    "object-curly-spacing": [
+      "off",
+    ],
+    "object-property-newline": [
+      "off",
+    ],
+    "one-var-declaration-per-line": [
+      "off",
+    ],
+    "operator-linebreak": [
+      "off",
+    ],
+    "padded-blocks": [
+      "off",
+    ],
+    "prefer-arrow-callback": [
+      "off",
+    ],
+    "prefer-const": [
+      "error",
+    ],
+    "prefer-promise-reject-errors": [
+      "off",
+    ],
+    "prefer-rest-params": [
+      "error",
+    ],
+    "prefer-spread": [
+      "error",
+    ],
+    "prettier/prettier": [
+      "error",
+    ],
+    "quote-props": [
+      "off",
+    ],
+    "quotes": [
+      0,
+    ],
+    "react/jsx-child-element-spacing": [
+      "off",
+    ],
+    "react/jsx-closing-bracket-location": [
+      "off",
+    ],
+    "react/jsx-closing-tag-location": [
+      "off",
+    ],
+    "react/jsx-curly-newline": [
+      "off",
+    ],
+    "react/jsx-curly-spacing": [
+      "off",
+    ],
+    "react/jsx-equals-spacing": [
+      "off",
+    ],
+    "react/jsx-first-prop-new-line": [
+      "off",
+    ],
+    "react/jsx-indent": [
+      "off",
+    ],
+    "react/jsx-indent-props": [
+      "off",
+    ],
+    "react/jsx-max-props-per-line": [
+      "off",
+    ],
+    "react/jsx-newline": [
+      "off",
+    ],
+    "react/jsx-one-expression-per-line": [
+      "off",
+    ],
+    "react/jsx-props-no-multi-spaces": [
+      "off",
+    ],
+    "react/jsx-space-before-closing": [
+      "off",
+    ],
+    "react/jsx-tag-spacing": [
+      "off",
+    ],
+    "react/jsx-wrap-multilines": [
+      "off",
+    ],
+    "require-await": [
+      "off",
+    ],
+    "require-yield": [
+      "error",
+    ],
+    "rest-spread-spacing": [
+      "off",
+    ],
+    "semi": [
+      "off",
+    ],
+    "semi-spacing": [
+      "off",
+    ],
+    "semi-style": [
+      "off",
+    ],
+    "simple-import-sort/exports": [
+      "error",
+    ],
+    "simple-import-sort/imports": [
+      "error",
+    ],
+    "sonarjs/accessor-pairs": [
+      "off",
+    ],
+    "sonarjs/alt-text": [
+      "error",
+    ],
+    "sonarjs/anchor-has-content": [
+      "error",
+    ],
+    "sonarjs/anchor-is-valid": [
+      "error",
+    ],
+    "sonarjs/anchor-precedence": [
+      "error",
+    ],
+    "sonarjs/argument-type": [
+      "error",
+    ],
+    "sonarjs/arguments-order": [
+      "error",
+    ],
+    "sonarjs/arguments-usage": [
+      "off",
+    ],
+    "sonarjs/array-callback-without-return": [
+      "error",
+    ],
+    "sonarjs/array-constructor": [
+      "off",
+    ],
+    "sonarjs/arrow-function-convention": [
+      "off",
+    ],
+    "sonarjs/assertions-in-tests": [
+      "error",
+    ],
+    "sonarjs/aws-apigateway-public-api": [
+      "error",
+    ],
+    "sonarjs/aws-ec2-rds-dms-public": [
+      "error",
+    ],
+    "sonarjs/aws-ec2-unencrypted-ebs-volume": [
+      "error",
+    ],
+    "sonarjs/aws-efs-unencrypted": [
+      "error",
+    ],
+    "sonarjs/aws-iam-all-privileges": [
+      "error",
+    ],
+    "sonarjs/aws-iam-all-resources-accessible": [
+      "off",
+    ],
+    "sonarjs/aws-iam-privilege-escalation": [
+      "error",
+    ],
+    "sonarjs/aws-iam-public-access": [
+      "error",
+    ],
+    "sonarjs/aws-opensearchservice-domain": [
+      "error",
+    ],
+    "sonarjs/aws-rds-unencrypted-databases": [
+      "error",
+    ],
+    "sonarjs/aws-restricted-ip-admin-access": [
+      "error",
+    ],
+    "sonarjs/aws-s3-bucket-granted-access": [
+      "error",
+    ],
+    "sonarjs/aws-s3-bucket-insecure-http": [
+      "error",
+    ],
+    "sonarjs/aws-s3-bucket-public-access": [
+      "error",
+    ],
+    "sonarjs/aws-s3-bucket-server-encryption": [
+      "off",
+    ],
+    "sonarjs/aws-s3-bucket-versioning": [
+      "error",
+    ],
+    "sonarjs/aws-sagemaker-unencrypted-notebook": [
+      "error",
+    ],
+    "sonarjs/aws-sns-unencrypted-topics": [
+      "error",
+    ],
+    "sonarjs/aws-sqs-unencrypted-queue": [
+      "error",
+    ],
+    "sonarjs/bitwise-operators": [
+      "error",
+    ],
+    "sonarjs/bool-param-default": [
+      "off",
+    ],
+    "sonarjs/brace-style": [
+      "off",
+    ],
+    "sonarjs/call-argument-line": [
+      "error",
+    ],
+    "sonarjs/certificate-transparency": [
+      "error",
+    ],
+    "sonarjs/chai-determinate-assertion": [
+      "error",
+    ],
+    "sonarjs/class-name": [
+      "error",
+    ],
+    "sonarjs/class-prototype": [
+      "off",
+    ],
+    "sonarjs/code-eval": [
+      "error",
+    ],
+    "sonarjs/cognitive-complexity": [
+      "error",
+    ],
+    "sonarjs/comma-or-logical-or-case": [
+      "error",
+    ],
+    "sonarjs/comment-regex": [
+      "off",
+    ],
+    "sonarjs/concise-regex": [
+      "error",
+    ],
+    "sonarjs/conditional-indentation": [
+      "off",
+    ],
+    "sonarjs/confidential-information-logging": [
+      "error",
+    ],
+    "sonarjs/constructor-for-side-effects": [
+      "error",
+    ],
+    "sonarjs/content-length": [
+      "error",
+    ],
+    "sonarjs/content-security-policy": [
+      "error",
+    ],
+    "sonarjs/cookie-no-httponly": [
+      "error",
+    ],
+    "sonarjs/cookies": [
+      "off",
+    ],
+    "sonarjs/cors": [
+      "error",
+    ],
+    "sonarjs/csrf": [
+      "error",
+    ],
+    "sonarjs/cyclomatic-complexity": [
+      "off",
+    ],
+    "sonarjs/declarations-in-global-scope": [
+      "off",
+    ],
+    "sonarjs/default-param-last": [
+      "error",
+    ],
+    "sonarjs/deprecation": [
+      "off",
+    ],
+    "sonarjs/destructuring-assignment-syntax": [
+      "off",
+    ],
+    "sonarjs/different-types-comparison": [
+      "error",
+    ],
+    "sonarjs/disabled-auto-escaping": [
+      "error",
+    ],
+    "sonarjs/disabled-resource-integrity": [
+      "error",
+    ],
+    "sonarjs/disabled-timeout": [
+      "error",
+    ],
+    "sonarjs/dns-prefetching": [
+      "off",
+    ],
+    "sonarjs/duplicates-in-character-class": [
+      "error",
+    ],
+    "sonarjs/elseif-without-else": [
+      "off",
+    ],
+    "sonarjs/empty-string-repetition": [
+      "error",
+    ],
+    "sonarjs/encryption": [
+      "off",
+    ],
+    "sonarjs/encryption-secure-mode": [
+      "error",
+    ],
+    "sonarjs/enforce-trailing-comma": [
+      "off",
+    ],
+    "sonarjs/existing-groups": [
+      "error",
+    ],
+    "sonarjs/expression-complexity": [
+      "off",
+    ],
+    "sonarjs/file-header": [
+      "off",
+    ],
+    "sonarjs/file-name-differ-from-class": [
+      "off",
+    ],
+    "sonarjs/file-permissions": [
+      "error",
+    ],
+    "sonarjs/file-uploads": [
+      "error",
+    ],
+    "sonarjs/fixme-tag": [
+      "error",
+    ],
+    "sonarjs/for-in": [
+      "off",
+    ],
+    "sonarjs/for-loop-increment-sign": [
+      "error",
+    ],
+    "sonarjs/frame-ancestors": [
+      "error",
+    ],
+    "sonarjs/function-inside-loop": [
+      "error",
+    ],
+    "sonarjs/function-name": [
+      "off",
+    ],
+    "sonarjs/function-return-type": [
+      "off",
+    ],
+    "sonarjs/future-reserved-words": [
+      "error",
+    ],
+    "sonarjs/generator-without-yield": [
+      "error",
+    ],
+    "sonarjs/hashing": [
+      "error",
+    ],
+    "sonarjs/hidden-files": [
+      "error",
+    ],
+    "sonarjs/hook-use-state": [
+      "error",
+    ],
+    "sonarjs/html-has-lang": [
+      "error",
+    ],
+    "sonarjs/in-operator-type-error": [
+      "error",
+    ],
+    "sonarjs/inconsistent-function-call": [
+      "error",
+    ],
+    "sonarjs/index-of-compare-to-positive-number": [
+      "error",
+    ],
+    "sonarjs/insecure-cookie": [
+      "error",
+    ],
+    "sonarjs/insecure-jwt-token": [
+      "error",
+    ],
+    "sonarjs/inverted-assertion-arguments": [
+      "error",
+    ],
+    "sonarjs/jsx-key": [
+      "error",
+    ],
+    "sonarjs/jsx-no-constructed-context-values": [
+      "error",
+    ],
+    "sonarjs/jsx-no-useless-fragment": [
+      "error",
+    ],
+    "sonarjs/label-has-associated-control": [
+      "error",
+    ],
+    "sonarjs/label-position": [
+      "error",
+    ],
+    "sonarjs/link-with-target-blank": [
+      "error",
+    ],
+    "sonarjs/max-switch-cases": [
+      "error",
+    ],
+    "sonarjs/max-union-size": [
+      "off",
+    ],
+    "sonarjs/media-has-caption": [
+      "error",
+    ],
+    "sonarjs/misplaced-loop-counter": [
+      "error",
+    ],
+    "sonarjs/mouse-events-a11y": [
+      "error",
+    ],
+    "sonarjs/nested-control-flow": [
+      "off",
+    ],
+    "sonarjs/new-cap": [
+      "error",
+    ],
+    "sonarjs/new-operator-misuse": [
+      "error",
+    ],
+    "sonarjs/no-accessor-field-mismatch": [
+      "error",
+    ],
+    "sonarjs/no-all-duplicated-branches": [
+      "error",
+    ],
+    "sonarjs/no-alphabetical-sort": [
+      "error",
+    ],
+    "sonarjs/no-angular-bypass-sanitization": [
+      "error",
+    ],
+    "sonarjs/no-array-delete": [
+      "error",
+    ],
+    "sonarjs/no-array-index-key": [
+      "error",
+    ],
+    "sonarjs/no-associative-arrays": [
+      "error",
+    ],
+    "sonarjs/no-async-constructor": [
+      "error",
+    ],
+    "sonarjs/no-base-to-string": [
+      "error",
+    ],
+    "sonarjs/no-built-in-override": [
+      "off",
+    ],
+    "sonarjs/no-case-label-in-switch": [
+      "error",
+    ],
+    "sonarjs/no-clear-text-protocols": [
+      "error",
+    ],
+    "sonarjs/no-code-after-done": [
+      "error",
+    ],
+    "sonarjs/no-collapsible-if": [
+      "off",
+    ],
+    "sonarjs/no-collection-size-mischeck": [
+      "error",
+    ],
+    "sonarjs/no-commented-code": [
+      "error",
+    ],
+    "sonarjs/no-dead-store": [
+      "error",
+    ],
+    "sonarjs/no-delete-var": [
+      "error",
+    ],
+    "sonarjs/no-deprecated-react": [
+      "error",
+    ],
+    "sonarjs/no-duplicate-in-composite": [
+      "error",
+    ],
+    "sonarjs/no-duplicate-string": [
+      "off",
+    ],
+    "sonarjs/no-duplicated-branches": [
+      "error",
+    ],
+    "sonarjs/no-element-overwrite": [
+      "error",
+    ],
+    "sonarjs/no-empty-after-reluctant": [
+      "error",
+    ],
+    "sonarjs/no-empty-alternatives": [
+      "error",
+    ],
+    "sonarjs/no-empty-collection": [
+      "error",
+    ],
+    "sonarjs/no-empty-function": [
+      "error",
+    ],
+    "sonarjs/no-empty-group": [
+      "error",
+    ],
+    "sonarjs/no-empty-interface": [
+      "off",
+    ],
+    "sonarjs/no-empty-test-file": [
+      "error",
+    ],
+    "sonarjs/no-equals-in-for-termination": [
+      "error",
+    ],
+    "sonarjs/no-exclusive-tests": [
+      "error",
+    ],
+    "sonarjs/no-extend-native": [
+      "error",
+    ],
+    "sonarjs/no-extra-arguments": [
+      "error",
+    ],
+    "sonarjs/no-extra-semi": [
+      "off",
+    ],
+    "sonarjs/no-find-dom-node": [
+      "error",
+    ],
+    "sonarjs/no-for-in-iterable": [
+      "off",
+    ],
+    "sonarjs/no-function-declaration-in-block": [
+      "off",
+    ],
+    "sonarjs/no-global-this": [
+      "error",
+    ],
+    "sonarjs/no-globals-shadowing": [
+      "error",
+    ],
+    "sonarjs/no-gratuitous-expressions": [
+      "error",
+    ],
+    "sonarjs/no-hardcoded-credentials": [
+      "error",
+    ],
+    "sonarjs/no-hardcoded-ip": [
+      "error",
+    ],
+    "sonarjs/no-hook-setter-in-body": [
+      "error",
+    ],
+    "sonarjs/no-identical-conditions": [
+      "error",
+    ],
+    "sonarjs/no-identical-expressions": [
+      "error",
+    ],
+    "sonarjs/no-identical-functions": [
+      "error",
+    ],
+    "sonarjs/no-ignored-exceptions": [
+      "off",
+    ],
+    "sonarjs/no-ignored-return": [
+      "error",
+    ],
+    "sonarjs/no-implicit-dependencies": [
+      "off",
+    ],
+    "sonarjs/no-implicit-global": [
+      "error",
+    ],
+    "sonarjs/no-in-misuse": [
+      "error",
+    ],
+    "sonarjs/no-incomplete-assertions": [
+      "error",
+    ],
+    "sonarjs/no-inconsistent-returns": [
+      "off",
+    ],
+    "sonarjs/no-incorrect-string-concat": [
+      "off",
+    ],
+    "sonarjs/no-infinite-loop": [
+      "error",
+    ],
+    "sonarjs/no-internal-api-use": [
+      "error",
+    ],
+    "sonarjs/no-intrusive-permissions": [
+      "error",
+    ],
+    "sonarjs/no-invalid-await": [
+      "error",
+    ],
+    "sonarjs/no-invariant-returns": [
+      "error",
+    ],
+    "sonarjs/no-inverted-boolean-check": [
+      "error",
+    ],
+    "sonarjs/no-ip-forward": [
+      "error",
+    ],
+    "sonarjs/no-labels": [
+      "error",
+    ],
+    "sonarjs/no-literal-call": [
+      "error",
+    ],
+    "sonarjs/no-lonely-if": [
+      "error",
+    ],
+    "sonarjs/no-mime-sniff": [
+      "error",
+    ],
+    "sonarjs/no-misleading-array-reverse": [
+      "error",
+    ],
+    "sonarjs/no-misused-promises": [
+      "error",
+    ],
+    "sonarjs/no-mixed-content": [
+      "error",
+    ],
+    "sonarjs/no-nested-assignment": [
+      "error",
+    ],
+    "sonarjs/no-nested-conditional": [
+      "error",
+    ],
+    "sonarjs/no-nested-functions": [
+      "warn",
+      {
+        "threshold": 5,
+      },
+    ],
+    "sonarjs/no-nested-incdec": [
+      "off",
+    ],
+    "sonarjs/no-nested-switch": [
+      "off",
+    ],
+    "sonarjs/no-nested-template-literals": [
+      "error",
+    ],
+    "sonarjs/no-one-iteration-loop": [
+      "error",
+    ],
+    "sonarjs/no-os-command-from-path": [
+      "error",
+    ],
+    "sonarjs/no-parameter-reassignment": [
+      "error",
+    ],
+    "sonarjs/no-primitive-wrappers": [
+      "error",
+    ],
+    "sonarjs/no-redeclare": [
+      "error",
+    ],
+    "sonarjs/no-redundant-assignments": [
+      "error",
+    ],
+    "sonarjs/no-redundant-boolean": [
+      "error",
+    ],
+    "sonarjs/no-redundant-jump": [
+      "error",
+    ],
+    "sonarjs/no-redundant-optional": [
+      "error",
+    ],
+    "sonarjs/no-redundant-parentheses": [
+      "off",
+    ],
+    "sonarjs/no-redundant-type-constituents": [
+      "error",
+    ],
+    "sonarjs/no-reference-error": [
+      "off",
+    ],
+    "sonarjs/no-referrer-policy": [
+      "error",
+    ],
+    "sonarjs/no-require-or-define": [
+      "off",
+    ],
+    "sonarjs/no-return-type-any": [
+      "off",
+    ],
+    "sonarjs/no-same-argument-assert": [
+      "error",
+    ],
+    "sonarjs/no-same-line-conditional": [
+      "error",
+    ],
+    "sonarjs/no-selector-parameter": [
+      "error",
+    ],
+    "sonarjs/no-self-compare": [
+      "error",
+    ],
+    "sonarjs/no-self-import": [
+      "error",
+    ],
+    "sonarjs/no-skipped-test": [
+      "error",
+    ],
+    "sonarjs/no-small-switch": [
+      "off",
+    ],
+    "sonarjs/no-tab": [
+      "off",
+    ],
+    "sonarjs/no-table-as-layout": [
+      "error",
+    ],
+    "sonarjs/no-this-alias": [
+      "off",
+    ],
+    "sonarjs/no-throw-literal": [
+      "error",
+    ],
+    "sonarjs/no-try-promise": [
+      "error",
+    ],
+    "sonarjs/no-undefined-argument": [
+      "error",
+    ],
+    "sonarjs/no-undefined-assignment": [
+      "off",
+    ],
+    "sonarjs/no-unenclosed-multiline-block": [
+      "error",
+    ],
+    "sonarjs/no-uniq-key": [
+      "error",
+    ],
+    "sonarjs/no-unknown-property": [
+      "error",
+    ],
+    "sonarjs/no-unreachable": [
+      "error",
+    ],
+    "sonarjs/no-unsafe": [
+      "error",
+    ],
+    "sonarjs/no-unsafe-unzip": [
+      "error",
+    ],
+    "sonarjs/no-unstable-nested-components": [
+      "error",
+    ],
+    "sonarjs/no-unthrown-error": [
+      "error",
+    ],
+    "sonarjs/no-unused-collection": [
+      "error",
+    ],
+    "sonarjs/no-unused-expressions": [
+      "error",
+    ],
+    "sonarjs/no-unused-function-argument": [
+      "off",
+    ],
+    "sonarjs/no-unused-private-class-members": [
+      "error",
+    ],
+    "sonarjs/no-use-of-empty-return-value": [
+      "error",
+    ],
+    "sonarjs/no-useless-call": [
+      "error",
+    ],
+    "sonarjs/no-useless-catch": [
+      "error",
+    ],
+    "sonarjs/no-useless-constructor": [
+      "error",
+    ],
+    "sonarjs/no-useless-increment": [
+      "error",
+    ],
+    "sonarjs/no-useless-intersection": [
+      "error",
+    ],
+    "sonarjs/no-useless-react-setstate": [
+      "error",
+    ],
+    "sonarjs/no-var": [
+      "error",
+    ],
+    "sonarjs/no-variable-usage-before-declaration": [
+      "off",
+    ],
+    "sonarjs/no-vue-bypass-sanitization": [
+      "error",
+    ],
+    "sonarjs/no-weak-cipher": [
+      "error",
+    ],
+    "sonarjs/no-weak-keys": [
+      "error",
+    ],
+    "sonarjs/no-wildcard-import": [
+      "off",
+    ],
+    "sonarjs/non-existent-operator": [
+      "error",
+    ],
+    "sonarjs/non-number-in-arithmetic-expression": [
+      "off",
+    ],
+    "sonarjs/null-dereference": [
+      "error",
+    ],
+    "sonarjs/object-alt-content": [
+      "error",
+    ],
+    "sonarjs/object-shorthand": [
+      "off",
+    ],
+    "sonarjs/operation-returning-nan": [
+      "off",
+    ],
+    "sonarjs/os-command": [
+      "error",
+    ],
+    "sonarjs/post-message": [
+      "error",
+    ],
+    "sonarjs/prefer-default-last": [
+      "error",
+    ],
+    "sonarjs/prefer-enum-initializers": [
+      "error",
+    ],
+    "sonarjs/prefer-for-of": [
+      "error",
+    ],
+    "sonarjs/prefer-function-type": [
+      "error",
+    ],
+    "sonarjs/prefer-immediate-return": [
+      "off",
+    ],
+    "sonarjs/prefer-namespace-keyword": [
+      "error",
+    ],
+    "sonarjs/prefer-nullish-coalescing": [
+      "off",
+    ],
+    "sonarjs/prefer-object-literal": [
+      "off",
+    ],
+    "sonarjs/prefer-object-spread": [
+      "error",
+    ],
+    "sonarjs/prefer-promise-shorthand": [
+      "error",
+    ],
+    "sonarjs/prefer-single-boolean-return": [
+      "error",
+    ],
+    "sonarjs/prefer-spread": [
+      "error",
+    ],
+    "sonarjs/prefer-string-starts-ends-with": [
+      "error",
+    ],
+    "sonarjs/prefer-template": [
+      "off",
+    ],
+    "sonarjs/prefer-type-guard": [
+      "error",
+    ],
+    "sonarjs/prefer-while": [
+      "error",
+    ],
+    "sonarjs/process-argv": [
+      "off",
+    ],
+    "sonarjs/production-debug": [
+      "error",
+    ],
+    "sonarjs/pseudo-random": [
+      "error",
+    ],
+    "sonarjs/public-static-readonly": [
+      "error",
+    ],
+    "sonarjs/publicly-writable-directories": [
+      "error",
+    ],
+    "sonarjs/reduce-initial-value": [
+      "error",
+    ],
+    "sonarjs/redundant-type-aliases": [
+      "error",
+    ],
+    "sonarjs/regex-complexity": [
+      "error",
+    ],
+    "sonarjs/regular-expr": [
+      "off",
+    ],
+    "sonarjs/rules-of-hooks": [
+      "error",
+    ],
+    "sonarjs/semi": [
+      "off",
+    ],
+    "sonarjs/session-regeneration": [
+      "error",
+    ],
+    "sonarjs/shorthand-property-grouping": [
+      "off",
+    ],
+    "sonarjs/single-char-in-character-classes": [
+      "error",
+    ],
+    "sonarjs/single-character-alternation": [
+      "error",
+    ],
+    "sonarjs/slow-regex": [
+      "error",
+    ],
+    "sonarjs/sockets": [
+      "off",
+    ],
+    "sonarjs/sonar-block-scoped-var": [
+      "error",
+    ],
+    "sonarjs/sonar-jsx-no-leaked-render": [
+      "error",
+    ],
+    "sonarjs/sonar-max-lines": [
+      "off",
+    ],
+    "sonarjs/sonar-max-lines-per-function": [
+      "off",
+    ],
+    "sonarjs/sonar-max-params": [
+      "error",
+    ],
+    "sonarjs/sonar-no-control-regex": [
+      "error",
+    ],
+    "sonarjs/sonar-no-dupe-keys": [
+      "error",
+    ],
+    "sonarjs/sonar-no-empty-character-class": [
+      "error",
+    ],
+    "sonarjs/sonar-no-fallthrough": [
+      "error",
+    ],
+    "sonarjs/sonar-no-invalid-regexp": [
+      "error",
+    ],
+    "sonarjs/sonar-no-magic-numbers": [
+      "off",
+    ],
+    "sonarjs/sonar-no-misleading-character-class": [
+      "error",
+    ],
+    "sonarjs/sonar-no-regex-spaces": [
+      "error",
+    ],
+    "sonarjs/sonar-no-unused-class-component-methods": [
+      "error",
+    ],
+    "sonarjs/sonar-no-unused-vars": [
+      "off",
+    ],
+    "sonarjs/sonar-prefer-optional-chain": [
+      "off",
+    ],
+    "sonarjs/sonar-prefer-read-only-props": [
+      "off",
+    ],
+    "sonarjs/sonar-prefer-regexp-exec": [
+      "error",
+    ],
+    "sonarjs/sql-queries": [
+      "error",
+    ],
+    "sonarjs/stable-tests": [
+      "error",
+    ],
+    "sonarjs/standard-input": [
+      "off",
+    ],
+    "sonarjs/stateful-regex": [
+      "error",
+    ],
+    "sonarjs/strict-transport-security": [
+      "error",
+    ],
+    "sonarjs/strings-comparison": [
+      "off",
+    ],
+    "sonarjs/super-invocation": [
+      "error",
+    ],
+    "sonarjs/switch-without-default": [
+      "off",
+    ],
+    "sonarjs/table-header": [
+      "error",
+    ],
+    "sonarjs/table-header-reference": [
+      "error",
+    ],
+    "sonarjs/test-check-exception": [
+      "error",
+    ],
+    "sonarjs/todo-tag": [
+      "off",
+    ],
+    "sonarjs/too-many-break-or-continue-in-loop": [
+      "off",
+    ],
+    "sonarjs/unicode-aware-regex": [
+      "off",
+    ],
+    "sonarjs/unnecessary-character-escapes": [
+      "error",
+    ],
+    "sonarjs/unused-import": [
+      "error",
+    ],
+    "sonarjs/unused-named-groups": [
+      "error",
+    ],
+    "sonarjs/unverified-certificate": [
+      "error",
+    ],
+    "sonarjs/unverified-hostname": [
+      "error",
+    ],
+    "sonarjs/updated-const-var": [
+      "error",
+    ],
+    "sonarjs/updated-loop-counter": [
+      "error",
+    ],
+    "sonarjs/use-isnan": [
+      "error",
+    ],
+    "sonarjs/use-type-alias": [
+      "off",
+    ],
+    "sonarjs/useless-string-operation": [
+      "off",
+    ],
+    "sonarjs/values-not-convertible-to-numbers": [
+      "off",
+    ],
+    "sonarjs/variable-name": [
+      "off",
+    ],
+    "sonarjs/void-use": [
+      "error",
+    ],
+    "sonarjs/weak-ssl": [
+      "error",
+    ],
+    "sonarjs/web-sql-database": [
+      "off",
+    ],
+    "sonarjs/x-powered-by": [
+      "error",
+    ],
+    "sonarjs/xml-parser-xxe": [
+      "error",
+    ],
+    "sonarjs/xpath": [
+      "off",
+    ],
+    "sort-destructure-keys/sort-destructure-keys": [
+      "error",
+    ],
+    "space-after-function-name": [
+      "off",
+    ],
+    "space-after-keywords": [
+      "off",
+    ],
+    "space-before-blocks": [
+      "off",
+    ],
+    "space-before-function-paren": [
+      "off",
+    ],
+    "space-before-function-parentheses": [
+      "off",
+    ],
+    "space-before-keywords": [
+      "off",
+    ],
+    "space-in-brackets": [
+      "off",
+    ],
+    "space-in-parens": [
+      "off",
+    ],
+    "space-infix-ops": [
+      "off",
+    ],
+    "space-return-throw-case": [
+      "off",
+    ],
+    "space-unary-ops": [
+      "off",
+    ],
+    "space-unary-word-ops": [
+      "off",
+    ],
+    "standard/array-bracket-even-spacing": [
+      "off",
+    ],
+    "standard/computed-property-even-spacing": [
+      "off",
+    ],
+    "standard/object-curly-even-spacing": [
+      "off",
+    ],
+    "switch-colon-spacing": [
+      "off",
+    ],
+    "template-curly-spacing": [
+      "off",
+    ],
+    "template-tag-spacing": [
+      "off",
+    ],
+    "typescript-sort-keys/interface": [
+      "error",
+    ],
+    "typescript-sort-keys/string-enum": [
+      "error",
+    ],
+    "unicorn/better-regex": [
+      "off",
+    ],
+    "unicorn/catch-error-name": [
+      "error",
+    ],
+    "unicorn/consistent-destructuring": [
+      "off",
+    ],
+    "unicorn/consistent-empty-array-spread": [
+      "error",
+    ],
+    "unicorn/consistent-existence-index-check": [
+      "error",
+    ],
+    "unicorn/consistent-function-scoping": [
+      "error",
+    ],
+    "unicorn/custom-error-definition": [
+      "off",
+    ],
+    "unicorn/empty-brace-spaces": [
+      "error",
+    ],
+    "unicorn/error-message": [
+      "error",
+    ],
+    "unicorn/escape-case": [
+      "error",
+    ],
+    "unicorn/expiring-todo-comments": [
+      "error",
+    ],
+    "unicorn/explicit-length-check": [
+      "error",
+    ],
+    "unicorn/filename-case": [
+      "error",
+    ],
+    "unicorn/import-style": [
+      "error",
+    ],
+    "unicorn/new-for-builtins": [
+      "error",
+    ],
+    "unicorn/no-abusive-eslint-disable": [
+      "error",
+    ],
+    "unicorn/no-anonymous-default-export": [
+      "error",
+    ],
+    "unicorn/no-array-callback-reference": [
+      "error",
+    ],
+    "unicorn/no-array-for-each": [
+      "error",
+    ],
+    "unicorn/no-array-method-this-argument": [
+      "error",
+    ],
+    "unicorn/no-array-push-push": [
+      "error",
+    ],
+    "unicorn/no-array-reduce": [
+      "error",
+    ],
+    "unicorn/no-await-expression-member": [
+      "error",
+    ],
+    "unicorn/no-await-in-promise-methods": [
+      "error",
+    ],
+    "unicorn/no-console-spaces": [
+      "error",
+    ],
+    "unicorn/no-document-cookie": [
+      "error",
+    ],
+    "unicorn/no-empty-file": [
+      "error",
+    ],
+    "unicorn/no-for-loop": [
+      "error",
+    ],
+    "unicorn/no-hex-escape": [
+      "error",
+    ],
+    "unicorn/no-instanceof-array": [
+      "error",
+    ],
+    "unicorn/no-invalid-fetch-options": [
+      "error",
+    ],
+    "unicorn/no-invalid-remove-event-listener": [
+      "error",
+    ],
+    "unicorn/no-keyword-prefix": [
+      "off",
+    ],
+    "unicorn/no-length-as-slice-end": [
+      "error",
+    ],
+    "unicorn/no-lonely-if": [
+      "error",
+    ],
+    "unicorn/no-magic-array-flat-depth": [
+      "error",
+    ],
+    "unicorn/no-negated-condition": [
+      "error",
+    ],
+    "unicorn/no-negation-in-equality-check": [
+      "error",
+    ],
+    "unicorn/no-nested-ternary": [
+      "error",
+    ],
+    "unicorn/no-new-array": [
+      "error",
+    ],
+    "unicorn/no-new-buffer": [
+      "error",
+    ],
+    "unicorn/no-null": [
+      "error",
+    ],
+    "unicorn/no-object-as-default-parameter": [
+      "error",
+    ],
+    "unicorn/no-process-exit": [
+      "error",
+    ],
+    "unicorn/no-single-promise-in-promise-methods": [
+      "error",
+    ],
+    "unicorn/no-static-only-class": [
+      "error",
+    ],
+    "unicorn/no-thenable": [
+      "error",
+    ],
+    "unicorn/no-this-assignment": [
+      "error",
+    ],
+    "unicorn/no-typeof-undefined": [
+      "error",
+    ],
+    "unicorn/no-unnecessary-await": [
+      "error",
+    ],
+    "unicorn/no-unnecessary-polyfills": [
+      "error",
+    ],
+    "unicorn/no-unreadable-array-destructuring": [
+      "error",
+    ],
+    "unicorn/no-unreadable-iife": [
+      "error",
+    ],
+    "unicorn/no-unused-properties": [
+      "off",
+    ],
+    "unicorn/no-useless-fallback-in-spread": [
+      "error",
+    ],
+    "unicorn/no-useless-length-check": [
+      "error",
+    ],
+    "unicorn/no-useless-promise-resolve-reject": [
+      "error",
+    ],
+    "unicorn/no-useless-spread": [
+      "error",
+    ],
+    "unicorn/no-useless-switch-case": [
+      "error",
+    ],
+    "unicorn/no-useless-undefined": [
+      "error",
+    ],
+    "unicorn/no-zero-fractions": [
+      "error",
+    ],
+    "unicorn/number-literal-case": [
+      "error",
+    ],
+    "unicorn/numeric-separators-style": [
+      "error",
+    ],
+    "unicorn/prefer-add-event-listener": [
+      "error",
+    ],
+    "unicorn/prefer-array-find": [
+      "error",
+    ],
+    "unicorn/prefer-array-flat": [
+      "error",
+    ],
+    "unicorn/prefer-array-flat-map": [
+      "error",
+    ],
+    "unicorn/prefer-array-index-of": [
+      "error",
+    ],
+    "unicorn/prefer-array-some": [
+      "error",
+    ],
+    "unicorn/prefer-at": [
+      "error",
+    ],
+    "unicorn/prefer-blob-reading-methods": [
+      "error",
+    ],
+    "unicorn/prefer-code-point": [
+      "error",
+    ],
+    "unicorn/prefer-date-now": [
+      "error",
+    ],
+    "unicorn/prefer-default-parameters": [
+      "error",
+    ],
+    "unicorn/prefer-dom-node-append": [
+      "error",
+    ],
+    "unicorn/prefer-dom-node-dataset": [
+      "error",
+    ],
+    "unicorn/prefer-dom-node-remove": [
+      "error",
+    ],
+    "unicorn/prefer-dom-node-text-content": [
+      "error",
+    ],
+    "unicorn/prefer-event-target": [
+      "error",
+    ],
+    "unicorn/prefer-export-from": [
+      "error",
+    ],
+    "unicorn/prefer-global-this": [
+      "error",
+    ],
+    "unicorn/prefer-includes": [
+      "error",
+    ],
+    "unicorn/prefer-json-parse-buffer": [
+      "off",
+    ],
+    "unicorn/prefer-keyboard-event-key": [
+      "error",
+    ],
+    "unicorn/prefer-logical-operator-over-ternary": [
+      "error",
+    ],
+    "unicorn/prefer-math-min-max": [
+      "error",
+    ],
+    "unicorn/prefer-math-trunc": [
+      "error",
+    ],
+    "unicorn/prefer-modern-dom-apis": [
+      "error",
+    ],
+    "unicorn/prefer-modern-math-apis": [
+      "error",
+    ],
+    "unicorn/prefer-module": [
+      "error",
+    ],
+    "unicorn/prefer-native-coercion-functions": [
+      "error",
+    ],
+    "unicorn/prefer-negative-index": [
+      "error",
+    ],
+    "unicorn/prefer-node-protocol": [
+      "error",
+    ],
+    "unicorn/prefer-number-properties": [
+      "error",
+    ],
+    "unicorn/prefer-object-from-entries": [
+      "error",
+    ],
+    "unicorn/prefer-optional-catch-binding": [
+      "error",
+    ],
+    "unicorn/prefer-prototype-methods": [
+      "error",
+    ],
+    "unicorn/prefer-query-selector": [
+      "error",
+    ],
+    "unicorn/prefer-reflect-apply": [
+      "error",
+    ],
+    "unicorn/prefer-regexp-test": [
+      "error",
+    ],
+    "unicorn/prefer-set-has": [
+      "error",
+    ],
+    "unicorn/prefer-set-size": [
+      "error",
+    ],
+    "unicorn/prefer-spread": [
+      "error",
+    ],
+    "unicorn/prefer-string-raw": [
+      "error",
+    ],
+    "unicorn/prefer-string-replace-all": [
+      "error",
+    ],
+    "unicorn/prefer-string-slice": [
+      "error",
+    ],
+    "unicorn/prefer-string-starts-ends-with": [
+      "error",
+    ],
+    "unicorn/prefer-string-trim-start-end": [
+      "error",
+    ],
+    "unicorn/prefer-structured-clone": [
+      "error",
+    ],
+    "unicorn/prefer-switch": [
+      "error",
+    ],
+    "unicorn/prefer-ternary": [
+      "error",
+    ],
+    "unicorn/prefer-top-level-await": [
+      "error",
+    ],
+    "unicorn/prefer-type-error": [
+      "error",
+    ],
+    "unicorn/prevent-abbreviations": [
+      "error",
+    ],
+    "unicorn/relative-url-style": [
+      "error",
+    ],
+    "unicorn/require-array-join-separator": [
+      "error",
+    ],
+    "unicorn/require-number-to-fixed-digits-argument": [
+      "error",
+    ],
+    "unicorn/require-post-message-target-origin": [
+      "off",
+    ],
+    "unicorn/string-content": [
+      "off",
+    ],
+    "unicorn/switch-case-braces": [
+      "error",
+    ],
+    "unicorn/template-indent": [
+      "error",
+    ],
+    "unicorn/text-encoding-identifier-case": [
+      "error",
+    ],
+    "unicorn/throw-new-error": [
+      "error",
+    ],
+    "use-isnan": [
+      "error",
+    ],
+    "valid-typeof": [
+      "error",
+    ],
+    "vue/array-bracket-newline": [
+      "off",
+    ],
+    "vue/array-bracket-spacing": [
+      "off",
+    ],
+    "vue/array-element-newline": [
+      "off",
+    ],
+    "vue/arrow-spacing": [
+      "off",
+    ],
+    "vue/block-spacing": [
+      "off",
+    ],
+    "vue/block-tag-newline": [
+      "off",
+    ],
+    "vue/brace-style": [
+      "off",
+    ],
+    "vue/comma-dangle": [
+      "off",
+    ],
+    "vue/comma-spacing": [
+      "off",
+    ],
+    "vue/comma-style": [
+      "off",
+    ],
+    "vue/dot-location": [
+      "off",
+    ],
+    "vue/func-call-spacing": [
+      "off",
+    ],
+    "vue/html-closing-bracket-newline": [
+      "off",
+    ],
+    "vue/html-closing-bracket-spacing": [
+      "off",
+    ],
+    "vue/html-end-tags": [
+      "off",
+    ],
+    "vue/html-indent": [
+      "off",
+    ],
+    "vue/html-quotes": [
+      "off",
+    ],
+    "vue/html-self-closing": [
+      0,
+    ],
+    "vue/key-spacing": [
+      "off",
+    ],
+    "vue/keyword-spacing": [
+      "off",
+    ],
+    "vue/max-attributes-per-line": [
+      "off",
+    ],
+    "vue/max-len": [
+      0,
+    ],
+    "vue/multiline-html-element-content-newline": [
+      "off",
+    ],
+    "vue/multiline-ternary": [
+      "off",
+    ],
+    "vue/mustache-interpolation-spacing": [
+      "off",
+    ],
+    "vue/no-extra-parens": [
+      "off",
+    ],
+    "vue/no-multi-spaces": [
+      "off",
+    ],
+    "vue/no-spaces-around-equal-signs-in-attribute": [
+      "off",
+    ],
+    "vue/object-curly-newline": [
+      "off",
+    ],
+    "vue/object-curly-spacing": [
+      "off",
+    ],
+    "vue/object-property-newline": [
+      "off",
+    ],
+    "vue/operator-linebreak": [
+      "off",
+    ],
+    "vue/quote-props": [
+      "off",
+    ],
+    "vue/script-indent": [
+      "off",
+    ],
+    "vue/singleline-html-element-content-newline": [
+      "off",
+    ],
+    "vue/space-in-parens": [
+      "off",
+    ],
+    "vue/space-infix-ops": [
+      "off",
+    ],
+    "vue/space-unary-ops": [
+      "off",
+    ],
+    "vue/template-curly-spacing": [
+      "off",
+    ],
+    "wrap-iife": [
+      "off",
+    ],
+    "wrap-regex": [
+      "off",
+    ],
+    "yield-star-spacing": [
+      "off",
+    ],
+  },
+  "settings": {
+    "import/extensions": [
+      ".ts",
+      ".cts",
+      ".mts",
+      ".tsx",
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".cjs",
+    ],
+    "import/external-module-folders": [
+      "node_modules",
+      "node_modules/@types",
+    ],
+    "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".mts",
+        ".tsx",
+      ],
+    },
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".ts",
+          ".cts",
+          ".mts",
+          ".tsx",
+          ".js",
+          ".jsx",
+          ".mjs",
+          ".cjs",
+        ],
+      },
+      "typescript": {
+        "alwaysTryTypes": true,
+      },
+    },
+    "react": {
+      "version": "999.999.999",
+    },
+  },
+}
+`;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -3,11 +3,20 @@ const { ESLint } = require("eslint");
 
 describe("validate config", () => {
   it(`load config file in ESLint to validate all rules are correct`, async () => {
-    const stringConfig = fs.readFileSync("./test.js", "utf8");
+    const stringConfig = fs.readFileSync("./test/sample.ts", "utf8");
 
     const cli = new ESLint({
       overrideConfigFile: "./index.js",
     });
+
+    const calculatedConfig =
+      await cli.calculateConfigForFile("./test/sample.ts");
+
+    // remove parser property from calculated config because it is env specific (fails in CI)
+    const { parser, ...calculatedConfigWithoutParserProperty } =
+      calculatedConfig;
+    // print all the rules
+    expect(calculatedConfigWithoutParserProperty).toMatchSnapshot();
 
     const lintResult = await cli.lintText(stringConfig);
 


### PR DESCRIPTION
Added a snapshot of the compiled rules for this package. 

pros:
now we can see which rules this package enables

cons:
perhaps harder to create a PR in github ui, as you'll have to update snapshots on change.