### PR TITLE
feat: add @typescript-eslint/strict-type-checking to config

### DIFF
--- a/docs/breaking-changes/v15.md
+++ b/docs/breaking-changes/v15.md
@@ -1,0 +1,3 @@
+# Breaking changes in v15
+
+Adds `@typescript-eslint/strict-type-checked` configuration, which will raise new errors in usages. The reliance on type checking is not new or breaking, since we already include `recommended-type-checked` in our config.

--- a/index.js
+++ b/index.js
@@ -109,6 +109,8 @@ module.exports = {
     "@typescript-eslint/no-deprecated": "off",
     /** Prefers `import type {}` syntax over `import { type }` if all imports are type-only */
     "@typescript-eslint/no-import-type-side-effects": "error",
+    /** A relatively stylistic rule, downgraded to "off" to limit breaking changes in the update that includes `strict-type-checked`. */
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
     /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is kept at a "warn" to be non-blocking. */
     "@typescript-eslint/no-unnecessary-condition": "warn",
     "@typescript-eslint/no-unused-vars": [

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
     /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is kept at a "warn" to be non-blocking. */
     "@typescript-eslint/no-unnecessary-condition": "warn",
+    /** There is readability benefit to passing in type arguments that match defaults. If defaults change, we may prefer the manual inspection of all the types changed, too. */
+    "@typescript-eslint/no-unnecessary-type-arguments": "off",
     /** Errors on generic type parameters that are only used once, even though that helps with return type inference. */
     "@typescript-eslint/no-unnecessary-type-parameters": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ module.exports = {
   ],
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@typescript-eslint/recommended-type-checked",
     "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:jest/recommended",

--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ module.exports = {
         prefer: "type-imports",
       },
     ],
+    /** Included as part of `strict-type-checked`, but nothing we want to enforce. */
+    "@typescript-eslint/no-deprecated": "off",
     /** Prefers `import type {}` syntax over `import { type }` if all imports are type-only */
     "@typescript-eslint/no-import-type-side-effects": "error",
     "@typescript-eslint/no-unused-vars": [

--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ module.exports = {
     "@typescript-eslint/no-import-type-side-effects": "error",
     /** A relatively stylistic rule, downgraded to "off" to limit breaking changes in the update that includes `strict-type-checked`. */
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
-    /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is kept at a "warn" to be non-blocking. */
-    "@typescript-eslint/no-unnecessary-condition": "warn",
+    /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is turned "off", as even "warn" auto-fixes source code. */
+    "@typescript-eslint/no-unnecessary-condition": "off",
     /** There is readability benefit to passing in type arguments that match defaults. If defaults change, we may prefer the manual inspection of all the types changed, too. */
     "@typescript-eslint/no-unnecessary-type-arguments": "off",
     /** Errors on generic type parameters that are only used once, even though that helps with return type inference. */

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
     /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is kept at a "warn" to be non-blocking. */
     "@typescript-eslint/no-unnecessary-condition": "warn",
+    /** Errors on generic type parameters that are only used once, even though that helps with return type inference. */
+    "@typescript-eslint/no-unnecessary-type-parameters": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/strict-type-checked",
     "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:jest/recommended",

--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ module.exports = {
         prefer: "type-imports",
       },
     ],
+    /** We do not need to force people to wrap `void`-return implicit arrow returns with braces just for a lint rule. TypeScript alone covers functionality, by the return type being `void`. */
+    "@typescript-eslint/no-confusing-void-expression": "off",
     /** Included as part of `strict-type-checked`, but nothing we want to enforce. */
     "@typescript-eslint/no-deprecated": "off",
     /** Prefers `import type {}` syntax over `import { type }` if all imports are type-only */

--- a/index.js
+++ b/index.js
@@ -109,6 +109,8 @@ module.exports = {
     "@typescript-eslint/no-deprecated": "off",
     /** Prefers `import type {}` syntax over `import { type }` if all imports are type-only */
     "@typescript-eslint/no-import-type-side-effects": "error",
+    /** This rule can help us identify syntax that is more defensive than the types suggest. Unfortunately, it may be protecting us from runtime errors where the type definitions are incorrect. As such, it is kept at a "warn" to be non-blocking. */
+    "@typescript-eslint/no-unnecessary-condition": "warn",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -797,7 +797,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-unnecessary-type-arguments": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-unnecessary-type-assertion": [
       "error",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -652,6 +652,9 @@ exports[`validate config load config file in ESLint to validate all rules are co
     ],
     "@typescript-eslint/ban-ts-comment": [
       "error",
+      {
+        "minimumDescriptionLength": 10,
+      },
     ],
     "@typescript-eslint/block-spacing": [
       "off",
@@ -700,10 +703,19 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/no-base-to-string": [
       "error",
     ],
+    "@typescript-eslint/no-confusing-void-expression": [
+      "error",
+    ],
+    "@typescript-eslint/no-deprecated": [
+      "error",
+    ],
     "@typescript-eslint/no-duplicate-enum-values": [
       "error",
     ],
     "@typescript-eslint/no-duplicate-type-constituents": [
+      "error",
+    ],
+    "@typescript-eslint/no-dynamic-delete": [
       "error",
     ],
     "@typescript-eslint/no-empty-object-type": [
@@ -721,6 +733,9 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/no-extra-semi": [
       "off",
     ],
+    "@typescript-eslint/no-extraneous-class": [
+      "error",
+    ],
     "@typescript-eslint/no-floating-promises": [
       "error",
     ],
@@ -733,16 +748,34 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/no-import-type-side-effects": [
       "error",
     ],
+    "@typescript-eslint/no-invalid-void-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-meaningless-void-operator": [
+      "error",
+    ],
     "@typescript-eslint/no-misused-new": [
       "error",
     ],
     "@typescript-eslint/no-misused-promises": [
       "error",
     ],
+    "@typescript-eslint/no-misused-spread": [
+      "error",
+    ],
+    "@typescript-eslint/no-mixed-enums": [
+      "error",
+    ],
     "@typescript-eslint/no-namespace": [
       "error",
     ],
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [
+      "error",
+    ],
     "@typescript-eslint/no-non-null-asserted-optional-chain": [
+      "error",
+    ],
+    "@typescript-eslint/no-non-null-assertion": [
       "error",
     ],
     "@typescript-eslint/no-redundant-type-constituents": [
@@ -754,10 +787,25 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/no-this-alias": [
       "error",
     ],
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-condition": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-template-expression": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-arguments": [
+      "error",
+    ],
     "@typescript-eslint/no-unnecessary-type-assertion": [
       "error",
     ],
     "@typescript-eslint/no-unnecessary-type-constraint": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-parameters": [
       "error",
     ],
     "@typescript-eslint/no-unsafe-argument": [
@@ -796,6 +844,9 @@ exports[`validate config load config file in ESLint to validate all rules are co
         "argsIgnorePattern": "^_",
       },
     ],
+    "@typescript-eslint/no-useless-constructor": [
+      "error",
+    ],
     "@typescript-eslint/no-wrapper-object-types": [
       "error",
     ],
@@ -808,10 +859,19 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/prefer-as-const": [
       "error",
     ],
+    "@typescript-eslint/prefer-literal-enum-member": [
+      "error",
+    ],
     "@typescript-eslint/prefer-namespace-keyword": [
       "error",
     ],
     "@typescript-eslint/prefer-promise-reject-errors": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-reduce-type-parameter": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-return-this-type": [
       "error",
     ],
     "@typescript-eslint/prefer-ts-expect-error": [
@@ -820,14 +880,36 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "@typescript-eslint/quotes": [
       0,
     ],
+    "@typescript-eslint/related-getter-setter-pairs": [
+      "error",
+    ],
     "@typescript-eslint/require-await": [
       "error",
     ],
     "@typescript-eslint/restrict-plus-operands": [
       "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": false,
+        "allowRegExp": false,
+      },
     ],
     "@typescript-eslint/restrict-template-expressions": [
       "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": false,
+        "allowRegExp": false,
+      },
+    ],
+    "@typescript-eslint/return-await": [
+      "error",
+      "error-handling-correctness-only",
     ],
     "@typescript-eslint/semi": [
       "off",
@@ -849,6 +931,12 @@ exports[`validate config load config file in ESLint to validate all rules are co
     ],
     "@typescript-eslint/unbound-method": [
       "off",
+    ],
+    "@typescript-eslint/unified-signatures": [
+      "error",
+    ],
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": [
+      "error",
     ],
     "array-bracket-newline": [
       "off",
@@ -1316,6 +1404,9 @@ exports[`validate config load config file in ESLint to validate all rules are co
     "no-reserved-keys": [
       "off",
     ],
+    "no-return-await": [
+      "off",
+    ],
     "no-self-assign": [
       "error",
     ],
@@ -1378,6 +1469,9 @@ exports[`validate config load config file in ESLint to validate all rules are co
     ],
     "no-useless-catch": [
       "error",
+    ],
+    "no-useless-constructor": [
+      "off",
     ],
     "no-useless-escape": [
       "error",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -704,7 +704,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-confusing-void-expression": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-deprecated": [
       "off",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -806,7 +806,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-unnecessary-type-parameters": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-unsafe-argument": [
       "error",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -791,7 +791,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-unnecessary-condition": [
-      "error",
+      "warn",
     ],
     "@typescript-eslint/no-unnecessary-template-expression": [
       "error",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -788,7 +788,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-unnecessary-condition": [
       "warn",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -707,7 +707,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "error",
     ],
     "@typescript-eslint/no-deprecated": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       "error",

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -791,7 +791,7 @@ exports[`validate config load config file in ESLint to validate all rules are co
       "off",
     ],
     "@typescript-eslint/no-unnecessary-condition": [
-      "warn",
+      "off",
     ],
     "@typescript-eslint/no-unnecessary-template-expression": [
       "error",


### PR DESCRIPTION
We recently had an EMT (https://github.com/turo/web-schumacher-app/pull/11277) that would've been prevented by a new rule `@typescript-eslint` added last month, as it is an edge case not handled correctly by TypeScript. However, that rule (https://typescript-eslint.io/rules/no-misused-spread/) would've only been automatically extended to repos if we enabled `strict-type-checked` configuration, which adds both the base `strict` and the `strict-type-checked` rules. This repo does not currently extend that configuration.

As such, this PR adds it and updates the tests, and sets up the changes as breaking.