### PR TITLE
fix: build config to include typed options instead of object typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "dependencies": {
     "@eslint/js": "9.29.0",
-    "typescript-eslint": "8.34.1",
     "@typescript-eslint/eslint-plugin": "8.34.1",
     "@typescript-eslint/parser": "8.34.1",
     "eslint-config-prettier": "10.1.5",
@@ -16,7 +15,8 @@
     "eslint-plugin-perfectionist": "4.14.0",
     "eslint-plugin-prettier": "5.4.1",
     "eslint-plugin-sonarjs": "3.0.2",
-    "eslint-plugin-unicorn": "56.0.1"
+    "eslint-plugin-unicorn": "56.0.1",
+    "typescript-eslint": "8.34.1"
   },
   "devDependencies": {
     "eslint": "9.29.0",
@@ -54,5 +54,6 @@
     "access": "public"
   },
   "repository": "https://github.com/open-turo/eslint-config-typescript",
-  "version": "16.0.7"
+  "version": "16.0.7",
+  "packageManager": "npm@11.4.2+sha512.f90c1ec8b207b625d6edb6693aef23dacb39c38e4217fe8c46a973f119cab392ac0de23fe3f07e583188dae9fd9108b3845ad6f525b598742bd060ebad60bff3"
 }


### PR DESCRIPTION
We're upgrading other repos to consume this repo and the `-react` repo for ESLint v9 support. The TypeScript inference is limited, though, due to non-strict JSDoc:

![Screenshot 2025-06-17 at 4 40 21 PM](https://github.com/user-attachments/assets/7c698314-739a-460a-aaa6-02cb4b30f546)

![Screenshot 2025-06-17 at 4 40 24 PM](https://github.com/user-attachments/assets/c63dfe58-cce4-47ad-8f2e-cfece0a4c207)

This PR adds more expressive JSDoc typing for improved type inference of parameters in usage.

![Screenshot 2025-06-17 at 4 46 21 PM](https://github.com/user-attachments/assets/91016cfa-48d0-432b-8603-1608a1034afe)
