### PR TITLE
fix: tweak TypeScript rules for vitest configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,6 +249,12 @@ const jestTestConfig = (options) => {
  * @param {boolean} options.typescript Whether to include typescript rules
  */
 const vitestTestConfig = (options) => {
+  const typescriptRules = options.typescript
+    ? /** @type {const} */ ({
+        "@typescript-eslint/unbound-method": "off",
+        "vitest/unbound-method": "error",
+      })
+    : {};
   return eslintConfig.defineConfig({
     extends: [vitestPlugin.configs.recommended],
     files: FILES_TEST,
@@ -257,6 +263,10 @@ const vitestTestConfig = (options) => {
       ...(options.typescript ? typescriptLanguageOptions() : {}),
     },
     plugins: { vitest: vitestPlugin },
+    rules: {
+      ...vitestPlugin.configs.recommended.rules,
+      ...typescriptRules,
+    },
   });
 };
 

--- a/test/__snapshots__/test.spec.js.snap
+++ b/test/__snapshots__/test.spec.js.snap
@@ -9796,6 +9796,12 @@ exports[`validate config the flat config with vitest is correct for index.js 1`]
   "vitest/require-local-test-context-for-concurrent-snapshots": [
     2,
   ],
+  "vitest/unbound-method": [
+    2,
+    {
+      "ignoreStatic": false,
+    },
+  ],
   "vitest/valid-describe-callback": [
     2,
   ],
@@ -13166,6 +13172,12 @@ exports[`validate config the flat config with vitest is correct for index.mjs 1`
   ],
   "vitest/require-local-test-context-for-concurrent-snapshots": [
     2,
+  ],
+  "vitest/unbound-method": [
+    2,
+    {
+      "ignoreStatic": false,
+    },
   ],
   "vitest/valid-describe-callback": [
     2,


### PR DESCRIPTION
@typescript-eslint/unbound-method doesn't understand vitest's expect context, causing false positives when asserting on mocked methods (e.g. expect(service.method).toHaveBeenCalled()). The vitest/unbound-method rule is a drop-in replacement that handles vitest patterns correctly.

When typescript: true, swap @typescript-eslint/unbound-method → vitest/unbound-method in vitest test configs
Spread vitestPlugin.configs.recommended.rules explicitly so the rule override takes effect
Risk: Low — only affects test files, and coverage is maintained via the vitest-aware rule.