### PR TITLE
fix: vitest allowModules default and monorepo tsconfig resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,7 @@ const config = function config(options = {}) {
   }
 
   const defaultAllowModules =
-    testFramework === "vitest" ? ["nock"] : ["@jest/globals", "nock"];
+    testFramework === "vitest" ? ["nock", "vitest"] : ["@jest/globals", "nock"];
   const allowModules = options.allowModules || defaultAllowModules;
 
   return eslintConfig.defineConfig(

--- a/index.js
+++ b/index.js
@@ -97,6 +97,17 @@ const importConfig = () =>
       "import/resolver": {
         typescript: {
           alwaysTryTypes: true,
+          /**
+           * Without an explicit `project`, the resolver caches a single tsconfig for the
+           * entire process (keyed by whatever the CWD was on first resolution). In a
+           * monorepo, running lint from the repo root (e.g. via pre-commit across
+           * packages) causes every file to resolve imports/aliases against just one
+           * package's tsconfig. Globbing for all tsconfigs makes the resolver pick the
+           * nearest one per file instead.
+           * @see https://github.com/import-js/eslint-import-resolver-typescript#project
+           */
+          noWarnOnMultipleProjects: true,
+          project: ["**/tsconfig.json"],
         },
       },
     },

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -237,4 +237,23 @@ describe("validate config", () => {
       'Invalid testFramework option: "invalid". Valid values are "jest" or "vitest".',
     );
   });
+
+  test.each(["jest", "vitest"])(
+    "n/no-unpublished-import allows importing the %s package by default",
+    async (testFramework) => {
+      const { default: config } = await import("../index.js");
+      const ESLint = await loadESLint({ useFlatConfig: true });
+      const linter = new ESLint({
+        baseConfig: config({ testFramework }),
+        overrideConfigFile: true,
+      });
+      const calculatedConfig =
+        await linter.calculateConfigForFile(TEST_FILE_PATH);
+      const [, { allowModules }] =
+        calculatedConfig.rules["n/no-unpublished-import"];
+      expect(allowModules).toContain(
+        testFramework === "vitest" ? "vitest" : "@jest/globals",
+      );
+    },
+  );
 });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -256,4 +256,18 @@ describe("validate config", () => {
       );
     },
   );
+
+  test("import/resolver typescript project globs all tsconfigs so files resolve against their own package", async () => {
+    const { default: config } = await import("../index.js");
+    const ESLint = await loadESLint({ useFlatConfig: true });
+    const linter = new ESLint({
+      baseConfig: config(),
+      overrideConfigFile: true,
+    });
+    const calculatedConfig =
+      await linter.calculateConfigForFile(TEST_FILE_PATH);
+    expect(
+      calculatedConfig.settings["import/resolver"].typescript.project,
+    ).toContain("**/tsconfig.json");
+  });
 });


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Fix vitest allowModules default and monorepo tsconfig resolution
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
**Problem 1:** when `testFramework: "vitest"` is configured, the default `n/no-unpublished-import` `allowModules` list omitted `vitest` itself, so importing it (e.g. in setup files not matched by the test file glob) was flagged as an unpublished import.

**Fix:** add `vitest` to the default allow list for that test framework.

**Problem 2:** `eslint-import-resolver-typescript` caches a single tsconfig for the entire lint process when no `project` option is configured, keyed by whatever the CWD was on first resolution. In a monorepo where pre-commit invokes eslint from the repo root across files spanning multiple packages, every file's import resolution (aliases like `~/*`) was resolved against just one package's tsconfig, causing `import/no-unresolved` false positives in every other package. Confirmed via eslint-import-resolver-typescript debug logs and reproduced directly against the resolver package.

**Fix:** configure `settings["import/resolver"].typescript.project` with a `**/tsconfig.json` glob so the resolver picks the tsconfig nearest to each file being linted, regardless of the CWD lint was invoked from. Also set `noWarnOnMultipleProjects` since matching multiple tsconfigs is expected/intended here.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix: allow importing vitest package in n/no-unpublished-import (+20/-1)
* fix: resolve per-package tsconfigs for import/no-unresolved in monorepos (+25/-0)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)