### PR TITLE
feat: exempt config files from import/no-default-export

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
 import openTuroTypescriptConfig from "./index.mjs";
 
-// eslint-disable-next-line import/no-default-export
 export default openTuroTypescriptConfig({ typescript: true });

--- a/index.js
+++ b/index.js
@@ -80,38 +80,51 @@ const getImportPluginFlatConfigs = () => {
 };
 
 const importConfig = () =>
-  eslintConfig.defineConfig({
-    extends: [getImportPluginFlatConfigs().recommended],
-    rules: {
-      "import/default": "off",
-      "import/named": "off",
-      "import/namespace": "off",
-      "import/no-default-export": "error",
-      "import/no-extraneous-dependencies": [
-        "error",
-        { devDependencies: [`eslint.config.${FILES_SRC_EXTENSION}`] },
-      ],
-      "import/prefer-default-export": "off",
-    },
-    settings: {
-      "import/resolver": {
-        typescript: {
-          alwaysTryTypes: true,
-          /**
-           * Without an explicit `project`, the resolver caches a single tsconfig for the
-           * entire process (keyed by whatever the CWD was on first resolution). In a
-           * monorepo, running lint from the repo root (e.g. via pre-commit across
-           * packages) causes every file to resolve imports/aliases against just one
-           * package's tsconfig. Globbing for all tsconfigs makes the resolver pick the
-           * nearest one per file instead.
-           * @see https://github.com/import-js/eslint-import-resolver-typescript#project
-           */
-          noWarnOnMultipleProjects: true,
-          project: ["**/tsconfig.json"],
+  eslintConfig.defineConfig(
+    {
+      extends: [getImportPluginFlatConfigs().recommended],
+      rules: {
+        "import/default": "off",
+        "import/named": "off",
+        "import/namespace": "off",
+        "import/no-default-export": "error",
+        "import/no-extraneous-dependencies": [
+          "error",
+          { devDependencies: [`eslint.config.${FILES_SRC_EXTENSION}`] },
+        ],
+        "import/prefer-default-export": "off",
+      },
+      settings: {
+        "import/resolver": {
+          typescript: {
+            alwaysTryTypes: true,
+            /**
+             * Without an explicit `project`, the resolver caches a single tsconfig for the
+             * entire process (keyed by whatever the CWD was on first resolution). In a
+             * monorepo, running lint from the repo root (e.g. via pre-commit across
+             * packages) causes every file to resolve imports/aliases against just one
+             * package's tsconfig. Globbing for all tsconfigs makes the resolver pick the
+             * nearest one per file instead.
+             * @see https://github.com/import-js/eslint-import-resolver-typescript#project
+             */
+            noWarnOnMultipleProjects: true,
+            project: ["**/tsconfig.json"],
+          },
         },
       },
     },
-  });
+    // Tools like ESLint and Vitest require default exports in their config files
+    {
+      files: [
+        `*.config.${FILES_SRC_EXTENSION}`,
+        `*.config.mjs`,
+        `*.config.cjs`,
+      ],
+      rules: {
+        "import/no-default-export": "off",
+      },
+    },
+  );
 
 const nPluginConfig = (allowModules = ["@jest/globals", "nock"]) =>
   eslintConfig.defineConfig({


### PR DESCRIPTION
## Summary

- Config files like `vitest.config.ts`, `eslint.config.mjs`, and similar patterns **require** default exports by convention. The shared ESLint config sets `import/no-default-export: "error"` globally, forcing every consumer repo to add its own workaround (disable comments, rule overrides, or ignores).
- This adds a config block that turns off `import/no-default-export` for `*.config.*` files matching the patterns `*.config.{js,jsx,ts,tsx,mjs,cjs,mts,cts,cjsx,mjsx,...}`.
- Also removes the now-unnecessary `eslint-disable` comment in this repo's own `eslint.config.mjs`.

## Changes

**`index.js`** — Added a new config object in the `config()` function (after `importConfig()`) that exempts config files:
```js
{
  files: [
    `*.config.${FILES_SRC_EXTENSION}`,
    `*.config.mjs`,
    `*.config.cjs`,
  ],
  rules: {
    "import/no-default-export": "off",
  },
}
```

**`eslint.config.mjs`** — Removed the `// eslint-disable-next-line import/no-default-export` comment since the new exemption now covers it.

## Test plan

- [x] `npm test` passes (all 10 tests, 4 snapshots)
- [x] `npm run lint` passes with no errors or warnings
- [ ] Verify consumer repos no longer need workarounds for config file default exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)